### PR TITLE
Simplify PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,7 +2,7 @@
 <!-- Are there any links to specifications, references from correspondances or similar that is relevant? Please add them here. -->
 
 ## List steps taken for own manual testing
-
+<!-- If your task is to set a field upon updating a node, and you just altered the code so that it looks correct, please also make sure you try to actually save a node. Maybe you want to save a couple of different node types even. -->
 
 ## Instructions for testing
 <!-- One such recipe would be to list the steps to deploy this branch locally, and the steps needed to test that the PR does what it is supposed to. -->
@@ -12,9 +12,9 @@
 
 ## Ny Media Pull Request Checklist (NMPRC)
 
-- [ ] Did you use the correct branch?
-- [ ] Does it require manual deployment?
-- [ ] Did you manually test the change?
-- [ ] Did you manually test the change in another project's repository?
+- [ ] Did you use the [correct branch](pull_request_template_explained.md#branching)?
+- [ ] Does it require [manual deployment](pull_request_template_explained.md#manual-deployment)?
+- [ ] Did you [manually test](pull_request_template_explained.md#manual-testing) the change?
+- [ ] Did you manually test the change in [another project's repository](pull_request_template_explained.md#manual-testing)?
 
 If you have suggestions for how this Pull Request Template can be better, please create an issue (or a pull request) on [https://github.com/nymedia/.github](https://github.com/nymedia/.github)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,4 @@
-## What is the objective of this PR.
+## What is the objective of this PR
 <!-- Are there any links to specifications, references from correspondances or similar that is relevant? Please add them here. -->
 
 ## List steps taken for own manual testing

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,69 +1,20 @@
-## Ny Media Pull Request Checklist (NMPRC)
+## What is the objective of this PR - can be a link to the issue or direct quote.
+<!-- Are there any links to specifications, references from correspondances or similar that is relevant? Please add them here. -->
 
+## List steps taken for own manual testing
 
-### Did you use the correct branch based on rules below?
-- [ ] If this is part of multi-PR effort - choose correct feature branch
-- [ ] If this is a one-PR change (bug fix or feature) use current branch
-
-### Does it require manual deployment? List manual deployment steps in the "Additional info" section below
-
-<details>
-<summary>What does manual deployment mean?</summary>
-
-Examples could be
-- Creating a node
-- Adding a block
-- Running a drush command
-- Adding a cron tab
-
-The goal should always be to not have any manual deployment steps. If you can for example create a node in an update hook instead, that is always much better.
-</details>
-
-- [ ] Yes, this requires manual deployment
-- [ ] Not, this does not require manual deployment
-
-### Did you manually test the change?
-
-<details>
-<summary>What does manual testing mean?</summary>
-
-If your task is to set a field upon updating a node, and you just altered the code so that it looks correct, please also make sure you try to actually save a node. Maybe you want to save a couple of different node types even.
-</details>
-
-- [ ] Yes, I manually tested my changes
-- [ ] No I did not manually test my changes (please specify why)
-
-### List steps taken for own manual testing
-
-Please fill in here
-
-### Did you manually test the change in another project's repository?
-
-Only applicable if this PR is towards a module repository used on several projects. Please also specify which projects you have tested it on. If you need info on which projects are using this module, ask someone. Please also indicate which repository you tested on.
-
-- [ ] Yes indeed. I tested the change on another repository.
-- [ ] No I did not
-- [ ] Not relevant
-
-Which repository?
-n/a.
-
-## Additional Info
-
-Are there any links to specifications, references from correspondances or similar that is relevant? Please add them here.
 
 ## Instructions for testing
+<!-- One such recipe would be to list the steps to deploy this branch locally, and the steps needed to test that the PR does what it is supposed to. -->
 
-<details>
-<summary>What does Instructions for testing mean?</summary>
+## Additional info
+<!-- Put some additional info here that doesn't fit any other places, for example list manual deployment steps -->
 
-One such recipe would be to list the steps to deploy this branch locally, and the steps needed to test that the PR does what it is supposed to. For example:
+## Ny Media Pull Request Checklist (NMPRC)
 
-- Run `composer build`
-- Log in as a user with "adminster nodes" permission
-- Edit a node of type "article" and click "Save"
-- The node should now have changed in some way.
-
-</details>
+- [ ] Did you use the correct branch?
+- [ ] Does it require manual deployment?
+- [ ] Did you manually test the change?
+- [ ] Did you manually test the change in another project's repository?
 
 If you have suggestions for how this Pull Request Template can be better, please create an issue (or a pull request) on [https://github.com/nymedia/.github](https://github.com/nymedia/.github)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,4 @@
-## What is the objective of this PR - can be a link to the issue or direct quote.
+## What is the objective of this PR.
 <!-- Are there any links to specifications, references from correspondances or similar that is relevant? Please add them here. -->
 
 ## List steps taken for own manual testing

--- a/pull_request_template_explained.md
+++ b/pull_request_template_explained.md
@@ -1,0 +1,25 @@
+# Pull Request template explained
+
+## Branching
+- If your PR is part of multi-PR effort - choose correct feature branch
+- If your PR is one-PR change (bug fix or feature) use latest branch
+
+## Manual deployment
+
+What does manual deployment mean?
+
+Examples could be
+- Creating a node
+- Adding a block
+- Running a drush command
+- Adding a cron tab
+
+The goal should always be to not have any manual deployment steps. If you can for example create a node in an update hook instead, that is always much better.
+
+## Manual testing
+
+What does manual testing mean?
+
+If your task is to set a field upon updating a node, and you just altered the code so that it looks correct, please also make sure you try to actually save a node. Maybe you want to save a couple of different node types even.
+
+If PR is towards a module repository used on several projects, please also specify which projects you have tested it on. If you need info on which projects are using this module, ask someone. Please also indicate which repository you tested on.


### PR DESCRIPTION
Here is an attempt to simplify the PR template as the current template may feel a little bit overwhelming. It's based on a simple checklist approach where one checks off only questions which are TRUE. Explanations are moved to a separate file to keep it simple for someone creating N+1 pull request so know all about processes already.